### PR TITLE
Use managed source directories to be inline with other sbt code generators.

### DIFF
--- a/src/main/scala/com/simplytyped/Antlr4Plugin.scala
+++ b/src/main/scala/com/simplytyped/Antlr4Plugin.scala
@@ -57,7 +57,7 @@ object Antlr4Plugin extends Plugin {
     antlr4GenListener := true,
     antlr4GenVisitor := false
   )) ++ Seq(
-    unmanagedSourceDirectories in Compile <+= (sourceDirectory in Antlr4),
+    managedSourceDirectories in Compile <+= (javaSource in Antlr4),
     sourceGenerators in Compile <+= (antlr4Generate in Antlr4),
     cleanFiles <+= (javaSource in Antlr4),
     libraryDependencies <+= (antlr4Dependency in Antlr4)


### PR DESCRIPTION
Here is how sbt-avro does it, https://github.com/cavorite/sbt-avro/blob/master/src/main/scala/sbtavro/SbtAvro.scala#L67

It interacts better with the sbt-idea plugin when you structure it like this too.  I would also recommend changing `/ "java"` javaSource to something more like https://github.com/cavorite/sbt-avro/blob/master/src/main/scala/sbtavro/SbtAvro.scala#L57

Thoughts?
