### PR TITLE
Use javaSource as sourceManaged in Compile

### DIFF
--- a/src/main/scala/com/simplytyped/Antlr4Plugin.scala
+++ b/src/main/scala/com/simplytyped/Antlr4Plugin.scala
@@ -50,7 +50,7 @@ object Antlr4Plugin extends Plugin {
 
   val antlr4Settings = inConfig(Antlr4)(Seq(
     sourceDirectory <<= (sourceDirectory in Compile) {_ / "antlr4"},
-    javaSource <<= (sourceManaged in Compile) {_ / "java"},
+    javaSource <<= sourceManaged in Compile,
     antlr4Generate <<= antlr4GeneratorTask,
     antlr4Dependency := "org.antlr" % "antlr4" % "4.1",
     antlr4PackageName := None,


### PR DESCRIPTION
According to the discussion here : https://groups.google.com/forum/#!topic/simple-build-tool/bdP6PLaYTDs 
I switched to javaSources as sourceManaged in Compile directly (not using a subdirectory 'java')

Now this plugin works well with sbteclipse plugin.
