### PR TITLE
Appends 'antlr4' to the javaSource directory for generated Java code.

### DIFF
--- a/src/main/scala/com/simplytyped/Antlr4Plugin.scala
+++ b/src/main/scala/com/simplytyped/Antlr4Plugin.scala
@@ -54,7 +54,7 @@ object Antlr4Plugin extends Plugin {
 
   val antlr4Settings = inConfig(Antlr4)(Seq(
     sourceDirectory <<= (sourceDirectory in Compile) {_ / "antlr4"},
-    javaSource <<= sourceManaged in Compile,
+    javaSource <<= (sourceManaged in Compile).apply(_ / "antlr4"),
     managedClasspath <<= (configuration, classpathTypes, update) map Classpaths.managedJars,
     antlr4Version := "4.5.1",
     antlr4Generate <<= antlr4GeneratorTask,


### PR DESCRIPTION
This fixes a problem that manifests itself when projects using this plugin are converted to IntelliJ projects using gen-idea. SBT expects plugins to put their generated source in a sub-directory of sourceManaged, named for the plugin. In order to support this, gen-idea appears to add the first level of directories under src_managed/main as "source paths" in the generated project, and so if you specify antlr4PackageName, the top level of the package hierarchy gets added as a project source path by accident. You can probably guess how well this works out.

Putting sbt-antlr4's generated code one level down, under 'antlr4', prevents this problem.