### PR TITLE
Change default directory for generated sources

### DIFF
--- a/src/main/scala/com/simplytyped/Antlr4Plugin.scala
+++ b/src/main/scala/com/simplytyped/Antlr4Plugin.scala
@@ -54,7 +54,7 @@ object Antlr4Plugin extends Plugin {
 
   val antlr4Settings = inConfig(Antlr4)(Seq(
     sourceDirectory <<= (sourceDirectory in Compile) {_ / "antlr4"},
-    javaSource <<= (sourceManaged in Compile).apply(_ / "antlr4"),
+    javaSource <<= (sourceManaged in Compile).apply(_ / "java"),
     managedClasspath <<= (configuration, classpathTypes, update) map Classpaths.managedJars,
     antlr4Version := "4.5.3",
     antlr4Generate <<= antlr4GeneratorTask,


### PR DESCRIPTION
The `src_managed` folder should by default adhere to the `main/language/package` convention. Generated sources are Java code, so they should end up in `src_managed/java/package`. This especially fixes source duplication bugs in IntelliJ.