### PR TITLE
Provide argument to antlr to treat warnings as error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ You can select an antl4 version with:
 
     antlr4PackageName in Antlr4 := Some("com.simplytyped")
 
-You can also adjust `-listener`, `-no-listener`, `-visitor`, `-no-visitor` options:
+You can also adjust `-listener`, `-no-listener`, `-visitor`, `-no-visitor`, `Werror` options:
 
     antlr4GenListener in Antlr4 := true // default: true
 
     antlr4GenVisitor in Antlr4 := false // default: false
+
+    antlr4TreatWarningsAsErrors in Antlr4 := true // default: false
  
 ## License
 

--- a/src/main/scala/com/simplytyped/Antlr4Plugin.scala
+++ b/src/main/scala/com/simplytyped/Antlr4Plugin.scala
@@ -62,7 +62,7 @@ object Antlr4Plugin extends AutoPlugin {
     val visitorArgs = if(visitorOpt) Seq("-visitor") else Seq("-no-visitor")
     val warningAsErrorArgs = if (warningsAsErrorOpt) Seq("-Werror") else Seq.empty
     val sourceArgs = srcFiles.map{_.toString}
-    val args = baseArgs ++ packageArgs ++ listenerArgs ++ visitorArgs ++ sourceArgs ++ warningAsErrorArgs
+    val args = baseArgs ++ packageArgs ++ listenerArgs ++ visitorArgs ++ warningAsErrorArgs ++ sourceArgs
     val exitCode = Process("java", args) ! log
     if(exitCode != 0) sys.error(s"Antlr4 failed with exit code $exitCode")
     (targetDir ** "*.java").get.toSet
@@ -80,7 +80,7 @@ object Antlr4Plugin extends AutoPlugin {
     antlr4PackageName := None,
     antlr4GenListener := true,
     antlr4GenVisitor := false,
-    antlr4TreatWarningsAsErrors := true
+    antlr4TreatWarningsAsErrors := false
   )) ++ Seq(
     ivyConfigurations += Antlr4,
     managedSourceDirectories in Compile += (javaSource in Antlr4).value,

--- a/src/main/scala/com/simplytyped/Antlr4Plugin.scala
+++ b/src/main/scala/com/simplytyped/Antlr4Plugin.scala
@@ -16,6 +16,7 @@ object Antlr4Plugin extends AutoPlugin {
     val antlr4PackageName = settingKey[Option[String]]("Name of the package for generated classes")
     val antlr4GenListener = settingKey[Boolean]("Generate listener")
     val antlr4GenVisitor = settingKey[Boolean]("Generate visitor")
+    val antlr4TreatWarningsAsErrors = settingKey[Boolean]("Treat warnings as errors when generating parser")
   }
   import autoImport._
 
@@ -28,6 +29,7 @@ object Antlr4Plugin extends AutoPlugin {
     val packageName = (antlr4PackageName in Antlr4).value
     val listenerOpt = (antlr4GenListener in Antlr4).value
     val visitorOpt = (antlr4GenVisitor in Antlr4).value
+    val warningsAsErrorOpt = (antlr4TreatWarningsAsErrors in Antlr4).value
     val cachedCompile = FileFunction.cached(streams.value.cacheDirectory / "antlr4", FilesInfo.lastModified, FilesInfo.exists) {
       in : Set[File] =>
         runAntlr(
@@ -37,7 +39,8 @@ object Antlr4Plugin extends AutoPlugin {
           log = log,
           packageName = packageName,
           listenerOpt = listenerOpt,
-          visitorOpt = visitorOpt
+          visitorOpt = visitorOpt,
+          warningsAsErrorOpt = warningsAsErrorOpt
         )
     }
     cachedCompile(((sourceDirectory in Antlr4).value ** "*.g4").get.toSet).toSeq
@@ -50,14 +53,16 @@ object Antlr4Plugin extends AutoPlugin {
       log: Logger,
       packageName: Option[String],
       listenerOpt: Boolean,
-      visitorOpt: Boolean) = {
+      visitorOpt: Boolean,
+      warningsAsErrorOpt: Boolean) = {
     val targetDir = packageName.map{_.split('.').foldLeft(targetBaseDir){_/_}}.getOrElse(targetBaseDir)
     val baseArgs = Seq("-cp", Path.makeString(classpath), "org.antlr.v4.Tool", "-o", targetDir.toString)
     val packageArgs = packageName.toSeq.flatMap{p => Seq("-package",p)}
     val listenerArgs = if(listenerOpt) Seq("-listener") else Seq("-no-listener")
     val visitorArgs = if(visitorOpt) Seq("-visitor") else Seq("-no-visitor")
+    val warningAsErrorArgs = if (warningsAsErrorOpt) Seq("-Werror") else Seq.empty
     val sourceArgs = srcFiles.map{_.toString}
-    val args = baseArgs ++ packageArgs ++ listenerArgs ++ visitorArgs ++ sourceArgs
+    val args = baseArgs ++ packageArgs ++ listenerArgs ++ visitorArgs ++ sourceArgs ++ warningAsErrorArgs
     val exitCode = Process("java", args) ! log
     if(exitCode != 0) sys.error(s"Antlr4 failed with exit code $exitCode")
     (targetDir ** "*.java").get.toSet
@@ -74,7 +79,8 @@ object Antlr4Plugin extends AutoPlugin {
     antlr4BuildDependency := antlr4Dependency.value % Antlr4.name,
     antlr4PackageName := None,
     antlr4GenListener := true,
-    antlr4GenVisitor := false
+    antlr4GenVisitor := false,
+    antlr4TreatWarningsAsErrors := true
   )) ++ Seq(
     ivyConfigurations += Antlr4,
     managedSourceDirectories in Compile += (javaSource in Antlr4).value,


### PR DESCRIPTION
Provide an option to users to instruct antlr to treat warnings as errors when generating the parser.
