### PR TITLE
add javaBinaryPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ You can also adjust `-listener`, `-no-listener`, `-visitor`, `-no-visitor`, `-We
     antlr4GenVisitor in Antlr4 := false // default: false
 
     antlr4TreatWarningsAsErrors in Antlr4 := true // default: false
+
+The plugin calls the java binary to execute ANTLR. By default it expects it in the path, but a custom path can be defined by the following setting:
+
+    javaBinaryPath in Antlr4 := Some("/usr/bin/java") // default: None
  
 ## License
 


### PR DESCRIPTION
I'm using a CI environment where the java binary isn't in the path, so `Process("java", args)` throws an exception, so it's really useful to add an option to set an explicit path to the java binary.