### PR TITLE
Add support for extra settings and custom source location

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Now, whenever you invoke `sbt compile` the ANTLR artifacts will be written to
 
 You can select an antl4 version with:
 
-    antlr4Version in Antlr4 := "4.8-1" // default: 4.8-1
+    antlr4Version in Antlr4 := "4.8-1" // default: 4.13.1
 
 `-package` option can be defined by the following setting:
 
@@ -43,6 +43,14 @@ You can also adjust `-listener`, `-no-listener`, `-visitor`, `-no-visitor`, `-We
     antlr4GenVisitor in Antlr4 := false // default: false
 
     antlr4TreatWarningsAsErrors in Antlr4 := true // default: false
+
+Any other flag can be specified manually with:
+
+    antlr4ExtraArgs in Antlr4 := Seq("-Dlanguage=JavaScript") // default: Seq()
+
+You can change the location of the grammar files with:
+
+    antlr4SourceDirectory in Antlr4 := baseDirectory.value / "antlr4" // default: (Compile / sourceDirectory).value / "antlr4"
  
 ## License
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,7 @@
 ## Version History
 
+  - `0.8.4`: Antlr 4.13.1, adding generic parameters support and grammar file location customization
+
   - `0.8.3`: Antlr 4.8-1
 
   - `0.8.2`: Antlr 4.7.2, adding -Werror option (@dilipbiswal)

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@
  */
 
 ThisBuild / organization := "com.simplytyped"
-ThisBuild / version := "0.8.3"
+ThisBuild / version := "0.8.4"
 
 lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin)


### PR DESCRIPTION
Working on a project where I need to run antlr against the same grammar in 2 different sub-projects, 1 being a normal scala project the other being a scala.js project. For the latter I also need to add an extra parameter to let antlr generate javascript code: I figured it would make sense to add a generic extra parameters setting for these kind of corner cases rather than add a direct mapping to the -language flag 

I noticed there are a couple of open and abandoned PRs, is the whole repo abandoned?